### PR TITLE
Fix incomplete `@reverse` term definitions

### DIFF
--- a/trld/jsonld/context.py
+++ b/trld/jsonld/context.py
@@ -635,10 +635,9 @@ class Term:
             # 13.7)
             active_context.terms[term] = self
             defined[term] = True
-            return
 
         # 14)
-        if ID in dfn and term != dfn[ID]:
+        elif ID in dfn and term != dfn[ID]:
             id: str = cast(str, dfn[ID]) # TODO: redundant cast for transpile
             # 14.1
             if id is None:


### PR DESCRIPTION
Don't `return` early at the end of step 13, and use `elif` in step 14. Otherwise, reverse terms won't have support for other compaction features, e.g. indexed containers.